### PR TITLE
feat: Remove SSR

### DIFF
--- a/pages/forgotPassword.tsx
+++ b/pages/forgotPassword.tsx
@@ -5,10 +5,6 @@ import { login, sendPasswordReset, signup, verifyPasswordReset } from '../lib/us
 import styles from './login.module.scss'
 import { verify } from 'crypto'
 
-export async function getServerSideProps(content) {
-  return {props: {...content.query}}
-} 
-
 export default function Login() {
   const router = useRouter()
   const [email, setEmail] = useState<string>('')

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,23 +1,29 @@
 import Head from 'next/head'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { login, signup } from '../lib/user'
 import styles from './login.module.scss'
 
-export async function getServerSideProps(content) {
-  return {props: {...content.query}}
-} 
-
-export default function Login(props: { email?: string, code?: string }) {
+export default function Login() {
   const router = useRouter()
-  const [isSignup, setSignup] = useState<boolean>(!!props.code)
-  const [email, setEmail] = useState<string>(props.email || '')
+  const [email, setEmail] = useState<string>('');
+  const [code, setCode] = useState<string>('');
+  const [alreadySignedUp, setAlreadySignedUp] = useState<boolean>(false)
   const [password, setPassword] = useState<string>('')
   const [passwordConfirmation, setPasswordConfirmation] = useState<string>('')
   const [firstName, setFirstName] = useState<string>('')
   const [lastName, setLastName] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string>(null)
+
+  const isSignup: boolean = !!code && !alreadySignedUp;
+
+  useEffect(() => {
+    const queryEmail: string = (router.query?.email || '').toString()
+    const queryCode: string = (router.query?.code || '').toString()
+    setEmail(queryEmail)
+    setCode(queryCode)
+  }, [router.query])
 
   function onSubmit(e: React.FormEvent): void {
     e.preventDefault()
@@ -40,7 +46,7 @@ export default function Login(props: { email?: string, code?: string }) {
     }
 
     if(isSignup) {
-      signup({ email, password, first_name: firstName, last_name: lastName, code: props.code }).then(onSuccess).catch(onError)
+      signup({ email, password, first_name: firstName, last_name: lastName, code }).then(onSuccess).catch(onError)
     } else {
       login(email, password).then(onSuccess).catch(onError)
     }
@@ -48,7 +54,7 @@ export default function Login(props: { email?: string, code?: string }) {
 
   function toggleSignup(e: React.MouseEvent<HTMLParagraphElement>) {
     if(loading) return
-    setSignup(!isSignup)
+    setAlreadySignedUp(true)
     setError(null)
   }
   

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -7,8 +7,7 @@ import styles from './login.module.scss'
 export default function Login() {
   const router = useRouter()
   const [email, setEmail] = useState<string>('');
-  const [code, setCode] = useState<string>('');
-  const [alreadySignedUp, setAlreadySignedUp] = useState<boolean>(false)
+  const [isSignup, setIsSignup] = useState<boolean>(false)
   const [password, setPassword] = useState<string>('')
   const [passwordConfirmation, setPasswordConfirmation] = useState<string>('')
   const [firstName, setFirstName] = useState<string>('')
@@ -16,14 +15,30 @@ export default function Login() {
   const [loading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string>(null)
 
-  const isSignup: boolean = !!code && !alreadySignedUp;
+  const queryCode = router.query.code
+  const code = Array.isArray(queryCode)
+    ? queryCode[0]
+    : !!queryCode
+    ? queryCode
+    : ''
 
   useEffect(() => {
-    const queryEmail: string = (router.query?.email || '').toString()
-    const queryCode: string = (router.query?.code || '').toString()
-    setEmail(queryEmail)
-    setCode(queryCode)
-  }, [router.query])
+    const queryEmail = router.query.email
+    setEmail(
+      Array.isArray(queryEmail)
+        ? queryEmail[0]
+        : !!queryEmail
+        ? queryEmail
+        : ''
+    )
+  }, [router.query.email])
+
+  useEffect(() => {
+    const queryCode = router.query.code
+    if (queryCode?.length > 0) {
+      setIsSignup(true)
+    }
+  }, [router.query.code])
 
   function onSubmit(e: React.FormEvent): void {
     e.preventDefault()
@@ -54,7 +69,7 @@ export default function Login() {
 
   function toggleSignup(e: React.MouseEvent<HTMLParagraphElement>) {
     if(loading) return
-    setAlreadySignedUp(true)
+    setIsSignup(prev => !prev)
     setError(null)
   }
   


### PR DESCRIPTION
471cee4 fix(/login): Correct login/signup toggling broken by prev commit

fe67e03 feat(SSR): Remove unnecessary SSR

`getServerSideProps` was only used to extract URL path. We can do this
client-side via next/router. Removing `getServerSideProps` allows these
pages to be statically generated and served via CDN.